### PR TITLE
Mark FIP 1 asset ownership withdrawn

### DIFF
--- a/FIPs/fip-1-allow-asset-owners-to-change-owner-key.mdx
+++ b/FIPs/fip-1-allow-asset-owners-to-change-owner-key.mdx
@@ -3,7 +3,7 @@ title: FIP-1 Allow asset owners to change owner key
 description: Allowing asset owners to change the owner key improves security and allows a best-practice of rotating the keys to minimize risk of leaking keys
 author: Mat Geist (@mat-if)
 discussion: https://discourse.ironfish.network/t/proposal-allow-asset-owners-to-change-owner-key/43
-status: Idea
+status: Withdrawn
 category: Core
 created: 2023-7-19
 ---


### PR DESCRIPTION
### What changed?

- Marking this FIP withdrawn since we have opted to go a different route. We're opting to expand the functionality, so it will be a more robust feature, and thus a separate FIP

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
