### PR TITLE
Update hardfork FIPs to last call

### DIFF
--- a/FIPs/fip-10-hardfork-1.mdx
+++ b/FIPs/fip-10-hardfork-1.mdx
@@ -3,7 +3,7 @@ title: FIP-10 Hardfork 1 (FishHash)
 description: Hardfork including the switch from Blake3 to FishHash as well as accompanying changes.
 author: Daniel (@danield9tqh), Mat (@mat-if)
 discussion: https://discourse.ironfish.network/t/88
-status: Review
+status: Last Call
 category: Hardfork
 created: '2024-1-14'
 requires: FIP-2, FIP-3, FIP-8, FIP-9

--- a/FIPs/fip-2-enforce-sequential-block-time.mdx
+++ b/FIPs/fip-2-enforce-sequential-block-time.mdx
@@ -3,7 +3,7 @@ title: FIP-2 Enforce Sequential Block Time
 description: Restrict block header from having timestamp earlier than previous block.
 authors: ygao76
 discussion: https://discourse.ironfish.network/t/proposal-restrict-block-from-having-timestamp-earlier-than-previous-block/50
-status: Review
+status: Last Call
 category: Core
 created: 2023-7-19
 ---

--- a/FIPs/fip-3-memory-hard-mining-algorithm.mdx
+++ b/FIPs/fip-3-memory-hard-mining-algorithm.mdx
@@ -3,7 +3,7 @@ title: FIP-3 Memory Hard Mining Algorithm (FishHash)
 description: Change the mining algorithm of Iron Fish to a memory hard POW algorithm
 author: Lollidieb (@Lolliedieb), Daniel (@danield9tqh), Mat (@mat-if)
 discussion: https://discourse.ironfish.network/t/proposal-memory-hard-mining-algorithm-fishhash/88
-status: Review
+status: Last Call
 category: Core
 created: '2023-12-20'
 ---

--- a/FIPs/fip-4-hash-based-checkpoints.mdx
+++ b/FIPs/fip-4-hash-based-checkpoints.mdx
@@ -3,7 +3,7 @@ title: FIP-4 Hash Based Checkpoints
 description: Add hash based checkpoints to the consensus layer
 author: Daniel (@danield9tqh), Mat (@mat-if)
 discussion: https://discourse.ironfish.network/t/91
-status: Review
+status: Last Call
 category: Core
 created: '2024-1-9'
 ---

--- a/FIPs/fip-8-difficulty-adjustment.mdx
+++ b/FIPs/fip-8-difficulty-adjustment.mdx
@@ -3,7 +3,7 @@ title: FIP-8 Difficulty adjustment
 description: Allowing the block difficulty to adjust faster per-block, and adjust the difficulty for a singular block for the FishHash transition
 author: Mat (@mat-if), Daniel (@danield9tqh)
 discussion: https://discourse.ironfish.network/t/longer-difficulty-adjustment-period
-status: Review
+status: Last Call
 category: Core
 created: '2024-02-13'
 ---

--- a/FIPs/fip-9-swap-randomness-and-graffiti.mdx
+++ b/FIPs/fip-9-swap-randomness-and-graffiti.mdx
@@ -3,7 +3,7 @@ title: FIP-9 Swap Randomness and Graffiti Header Positions
 description: Swap the positions of the randomness and graffiti in the serialized block header when mining
 author: Daniel (@danield9tqh), Mat (@mat-if)
 discussion: https://discourse.ironfish.network/t/93
-status: Review
+status: Last Call
 category: Core
 created: '2024-02-13'
 ---


### PR DESCRIPTION
### What changed?

With hardfork changes going into testnet, moving hardfork FIPs to 'Last Call' for at least 14 days for comment before finalizing the mainnet hardfork

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
